### PR TITLE
Change Dependabot update interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     commit-message:
       prefix: '[npm] '
     groups:
@@ -13,7 +13,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     commit-message:
       prefix: '[actions] '
     groups:


### PR DESCRIPTION
Changed the update schedule from weekly to monthly for npm and GitHub Actions.